### PR TITLE
Add group norms and summary for Milestone 0

### DIFF
--- a/collaboration/README.md
+++ b/collaboration/README.md
@@ -1,5 +1,52 @@
-# Collaboration
+# 🧑‍🤝‍🧑 Group Norms – MIT ET6 CDSP Group 06
 
-<!-- group norms summary -->
+## 🧭 Summary
 
-<!-- group norms list -->
+We are a collaborative team committed to respectful,
+transparent communication and shared learning.
+Our goal is to create a psychologically safe environment where trust,
+flexibility, and accountability allow us to grow together through this project.
+
+---
+
+## 💡 Intention-Based Norms
+
+1. **We respect each other's time** in both synchronous and asynchronous communication.
+2. **We strive for transparency** in decisions, expectations, and progress.
+3. **We give and receive feedback** constructively, aiming to improve—not to criticize.
+4. **We assume positive intent** and remain open-minded when cultural or  
+   communication differences arise.
+5. **We hold ourselves accountable** to shared goals and deadlines while showing
+   empathy toward challenges.
+6. **We prioritize cognitive trust** by consistently demonstrating effort,  
+   reliability, and professionalism.
+7. **We address tension or conflict respectfully**, seeking resolution and  
+   learning, not blame.
+8. **We value both discussion and debate**, and agree to pause if either becomes
+   unproductive.
+9. **We continuously improve** our norms as needed throughout the project lifecycle.
+
+---
+
+## 🧠 Notes from Brainstorming
+
+- Building trust means showing follow-through, clarity, and empathy.
+- Respect means listening, not interrupting, and acknowledging others' input.
+- Disagreements should be addressed openly but kindly.
+- Slack/Discord ... for informal chat, GitHub for structured tasks and updates.
+- Use structured meeting agendas to stay efficient.
+- Every team member should feel ownership of part of the project.
+- If trust is damaged, acknowledge it and repair it openly.
+
+---
+
+## ✏️ Our Group Name
+
+**To be Announced Later** 🎵⚛️  
+
+---
+
+## 🔄 Living Document
+
+This file is a living document and will evolve as our group grows. We revisit
+these norms during milestone retrospectives and update them if needed.


### PR DESCRIPTION
### Summary
This PR adds our team's group norms and a 2-sentence onboarding summary to the `/collaboration/README.md` file, as part of Milestone 0 (Cross-Cultural Collaboration).

### Changes
- Added intention-based norms
- Added team values summary
- Prepared file to evolve as a living document

### Related
Closes #7 